### PR TITLE
remove functions that were added in PT6 refactor

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
         run: msbuild /m /v:minimal /p:Configuration=${{matrix.configuration}} /p:PlatformTarget=x86 build/t6-gsc-utils.sln
 
       - name: Upload ${{matrix.configuration}} binaries
-        uses: actions/upload-artifact@v3.1.3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{matrix.configuration}} binaries
           path: |

--- a/README.md
+++ b/README.md
@@ -26,24 +26,6 @@ init()
 ```
 
 ## Misc
-* `getFunction(filename, name)`: Gets a function from a GSC script.
-
-  ```c
-  init()
-  {
-      function = getFunction("maps/mp/gametypes/_callbacksetup", "callbackVoid");
-      [[ function ]]();
-  }
-  ```
-* `getFunctionName(function)`: Returns the function's name.
-  
-  ```c
-  init()
-  {
-      function = getFunction("maps/mp/gametypes/_callbacksetup", "callbackVoid");
-      print(getFunctionName(function)); // "maps/mp/gametypes/_callbacksetup::callbackVoid"
-  }
-  ```
 * `arrayRemoveKey(array, key)`: Removes an array element by its (string) key.
 
   ```c
@@ -760,8 +742,6 @@ The values are stored as strings but all the functions below can take either a s
 * `getcurrentthread`
 * `printcallstack`
 * `getcallstack`
-* `getfunction`
-* `getfunctionname`
 * `getfunctionargcount`
 * `arrayremovekey`
 * `xor`
@@ -778,9 +758,6 @@ The values are stored as strings but all the functions below can take either a s
 * `typeof`
 * `worldget`
 * `worldset`
-* `invokefunc`
-* `detourfunc`
-* `disabledetour`
 * `http::get`
 * `httpget`
 * `curl`

--- a/src/component/gsc.cpp
+++ b/src/component/gsc.cpp
@@ -44,8 +44,6 @@ namespace gsc
 
 		std::unordered_map<std::string, scripting::script_value> world;
 
-		std::unordered_map<void*, const char*> hooked_builtins;
-
 		utils::hook::detour scr_error_internal_hook;
 
 		std::atomic_bool disable_longjmp_error = false;
@@ -290,21 +288,6 @@ namespace gsc
 		}
 	}
 
-	bool execute_hook(const void* ptr)
-	{
-		const auto iter = hooked_builtins.find(reinterpret_cast<void*>(
-			reinterpret_cast<size_t>(ptr)));
-		if (iter == hooked_builtins.end())
-		{
-			return false;
-		}
-
-		scripting::function function(iter->second);
-		function.call(*game::levelEntityId, get_arguments());
-
-		return true;
-	}
-
 	void call_function(const function_t& function, const std::string& name)
 	{
 		const auto args = get_arguments();
@@ -448,11 +431,6 @@ namespace gsc
 
 			utils::hook::jump(SELECT(0x8F3F60, 0x8F2CC0), SELECT(scr_error_internal_stub_1_mp, scr_error_internal_stub_1_zm));
 			scr_error_internal_hook.create(SELECT(0x8F3F60, 0x8F2CC0), scr_error_internal_stub);
-
-			scripting::on_shutdown([&]
-			{
-				hooked_builtins.clear();
-			});
 
 			field::add(classid::entity, "eflags",
 				[](unsigned int entnum) -> scripting::script_value
@@ -629,51 +607,6 @@ namespace gsc
 			function::add("worldset", [](const std::string& key, const scripting::script_value& value)
 			{
 				world[key] = value;
-			});
-
-			function::add("invokefunc", [](const std::string& name, const scripting::variadic_args& args)
-			{
-				const auto lower = utils::string::to_lower(name);
-
-				std::vector<scripting::script_value> arguments;
-				for (const auto& arg : args)
-				{
-					arguments.emplace_back(arg);
-				}
-
-				disable_longjmp_error = true;
-
-				const auto _0 = gsl::finally([&]
-				{
-					*reinterpret_cast<const char**>(SELECT(0x2E27C70, 0x2DF7F70)) = nullptr;
-					disable_longjmp_error = false;
-				});
-
-				return scripting::call(lower, arguments);
-			});
-
-			function::add("detourfunc", [](const std::string& name, const scripting::function& stub)
-			{
-				const auto iter = scripting::function_map.find(name);
-				if (iter == scripting::function_map.end())
-				{
-					throw std::runtime_error("function not found");
-				}
-
-				const auto func = iter->second.actionFunc;
-				hooked_builtins[func] = stub.get_pos();
-			});
-
-			function::add("disabledetour", [](const std::string& name)
-			{
-				const auto iter = scripting::function_map.find(name);
-				if (iter == scripting::function_map.end())
-				{
-					throw std::runtime_error("function not found");
-				}
-
-				const auto func = iter->second.actionFunc;
-				hooked_builtins.erase(func);
 			});
 		}
 	};

--- a/src/component/gsc.hpp
+++ b/src/component/gsc.hpp
@@ -76,8 +76,6 @@ namespace gsc
 	std::string find_builtin_name(void* function);
 	std::string find_builtin_method_name(void* function);
 
-	bool execute_hook(const void* ptr);
-
 	void call_function(const function_t& function, const std::string& name);
 	void call_method(const function_t& method, const std::string& name, const game::scr_entref_t entref);
 

--- a/src/component/patches.cpp
+++ b/src/component/patches.cpp
@@ -35,52 +35,6 @@ namespace patches
 
 			return result;
 		}
-
-		void execute_with_seh_wrap(const scripting::safe_execution::script_function function, 
-			const game::scr_entref_t entref)
-		{
-			if (gsc::execute_hook(function))
-			{
-				return;
-			}
-
-			if (!scripting::safe_execution::execute_with_seh(function, entref))
-			{
-				game::Scr_Error(game::SCRIPTINSTANCE_SERVER, "exception handled", false);
-			}
-		}
-
-		void call_builtin_stub(utils::hook::assembler& a)
-		{
-			a.mov(dword_ptr(SELECT(0x2E1A5E0, 0x2DEA8E0), eax), esi);
-
-			a.pushad();
-			a.push(0);
-			a.push(0);
-			a.push(ecx);
-			a.call(execute_with_seh_wrap);
-			a.add(esp, 0xC);
-			a.popad();
-
-			a.jmp(SELECT(0x8F6401, 0x8F5161));
-		}
-
-		void call_builtin_method_stub(utils::hook::assembler& a)
-		{
-			a.mov(dword_ptr(edx), ebx);
-
-			a.pushad();
-			a.push(eax);
-			a.push(esi);
-			a.push(dword_ptr(ebp, 0x2C));
-			a.call(execute_with_seh_wrap);
-			a.add(esp, 0xC);
-			a.popad();
-
-			a.add(esp, 0x18);
-
-			a.jmp(SELECT(0x8F6498, 0x8F51F8));
-		}
 	}
 
 	class component final : public component_interface
@@ -98,9 +52,6 @@ namespace patches
 
 		void patch()
 		{
-			utils::hook::jump(SELECT(0x8F63F9, 0x8F5159), utils::hook::assemble(call_builtin_stub));
-			utils::hook::jump(SELECT(0x8F6490, 0x8F51F0), utils::hook::assemble(call_builtin_method_stub));
-
 			sv_display_clan_tag = game::Dvar_RegisterBool("sv_display_clan_tag", false, 0, "Display the clan tag in the game log");
 			utils::hook::call(SELECT(0x820F1C, 0x81F91C), cs_display_name_stub);
 		}


### PR DESCRIPTION
- getfunction & getfunctionname added to PT6, 1:1 with t6-gsc-utils previous implementation
- detours were added. you can disable it on a per-call basis, and invoke the original this way:
![image](https://github.com/user-attachments/assets/be2fcd6f-b7c5-4ed0-bec8-2c76acb4ab23)
- fixed workflow ;)

additional note that plutonium now supports IO GSC functions, and it's even sandboxed. ill maybe make a PR to remove at later date as im too lazy to update my mod to use their new stuff lol
![image](https://github.com/user-attachments/assets/27530403-52ff-4963-b691-af7d3f60df2c)
